### PR TITLE
Add 'Green Demo' built-in theme (green background for demo)

### DIFF
--- a/extensions/theme-green-demo/README.md
+++ b/extensions/theme-green-demo/README.md
@@ -1,0 +1,13 @@
+# Green Demo Theme
+
+A very simple built-in color theme that turns the workbench and editor backgrounds green for demo screenshots.
+
+## How to use
+
+1. Open the Command Palette.
+   - Windows/Linux: `Ctrl` + `K`, then `Ctrl` + `T`
+   - macOS: `⌘` + `K`, then `⌘` + `T`
+2. Choose "Color Theme".
+3. Select "Green Demo".
+
+You should see greenish hues across the editor and workbench suitable for a screenshot.

--- a/extensions/theme-green-demo/package.json
+++ b/extensions/theme-green-demo/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "theme-green-demo",
+  "displayName": "Green Demo",
+  "description": "A simple green demo theme for screenshot purposes.",
+  "version": "0.0.1",
+  "publisher": "vscode",
+  "license": "MIT",
+  "engines": {
+    "vscode": "*"
+  },
+  "categories": ["Themes"],
+  "contributes": {
+    "themes": [
+      {
+        "id": "green-demo",
+        "label": "Green Demo",
+        "uiTheme": "vs-dark",
+        "path": "./themes/green-color-theme.json"
+      }
+    ]
+  },
+  "activationEvents": []
+}

--- a/extensions/theme-green-demo/themes/green-color-theme.json
+++ b/extensions/theme-green-demo/themes/green-color-theme.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "Green Demo",
+  "type": "dark",
+  "colors": {
+    "activityBar.background": "#002200",
+    "sideBar.background": "#002a00",
+    "editor.background": "#003300",
+    "editor.foreground": "#E6FFE6",
+    "editorLineNumber.foreground": "#66aa66",
+    "editorGroupHeader.tabsBackground": "#002a00",
+    "tab.activeBackground": "#003300",
+    "tab.inactiveBackground": "#002a00",
+    "titleBar.activeBackground": "#003300",
+    "titleBar.inactiveBackground": "#002a00",
+    "statusBar.background": "#003300",
+    "editorWidget.background": "#002a00",
+    "focusBorder": "#006600",
+    "selection.background": "#00660055"
+  },
+  "tokenColors": [
+    { "settings": { "foreground": "#E6FFE6" } },
+    { "scope": "comment", "settings": { "foreground": "#8FBF8F", "fontStyle": "italic" } },
+    { "scope": "string", "settings": { "foreground": "#B7FFB7" } },
+    { "scope": "keyword", "settings": { "foreground": "#7FE57F" } }
+  ],
+  "semanticHighlighting": true
+}


### PR DESCRIPTION
Summary
- Add a simple built-in theme under `extensions/theme-green-demo/` for demo screenshots.
- `package.json` contributes a theme labeled "Green Demo" with `uiTheme: vs-dark`.
- `themes/green-color-theme.json` sets greenish workbench/editor colors (e.g. `editor.background: #003300`, `sideBar.background: #002a00`, `activityBar.background: #002200`) and minimal token colors.
- `README.md` documents how to select the theme via the Color Theme picker.

Nature of change
- New built-in theme (demo-only)

Impact
- None to product functionality; intended for taking a green-background screenshot.

Why
- Provide an easy way to switch to a very green workbench/editor for a demo screenshot.
