### PR TITLE
Demo: set default background to green

### DIFF
--- a/CAPY-DEMO.txt
+++ b/CAPY-DEMO.txt
@@ -1,1 +1,2 @@
 Demo: This file was created to demonstrate a write operation during the background color change to green.
+Update: additional minor edits applied.

--- a/DEMO-BACKGROUND.md
+++ b/DEMO-BACKGROUND.md
@@ -7,3 +7,7 @@ Files touched:
 - CAPY-DEMO.txt (marker)
 
 This file exists to make the demo more traceable.
+
+## Updates
+- Removed redundant html override
+- Added minor .part tint and kept lists readable

--- a/capy-demo.json
+++ b/capy-demo.json
@@ -1,1 +1,1 @@
-{"background":"green","scope":"workbench-visible"}
+{"background":"green","scope":"workbench-visible","rev":2}

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -322,5 +322,9 @@ body {
 /* Demo: force green background */
 body, .monaco-workbench { background-color: green !important; }
 
-html { background-color: green !important; }
 .monaco-workbench.border { background-color: green !important; }
+
+/* Demo: minor tweaks */
+.monaco-workbench .part { background-color: rgba(0,128,0,0.03) !important; }
+/* Keep lists readable */
+.monaco-workbench .monaco-list:focus { background-color: inherit; }


### PR DESCRIPTION
- Change default workbench background to green for demonstration purposes
- Adds a small CAPY-DEMO.txt marker file to illustrate a write op

Scope: visual background only; overrides via CSS appended to workbench style.css.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/49e6596b-4ece-4a5a-a8f5-eac89eee79b0/task/816342f3-8da8-4252-a79c-83c097ca5ff1))