### PR TITLE
AI Agent: Selectable Grok models with stubbed demo responses

### DIFF
--- a/extensions/ai-agent/README.md
+++ b/extensions/ai-agent/README.md
@@ -7,6 +7,11 @@ A minimal built-in extension that contributes an AI activity bar icon and a side
 - Commands:
   - `AI: Open Chat Sidebar` (`aiAgent.open`) focuses the AI view container
   - `AI: Send Message` (`aiAgent.sendMessage`) posts a stubbed echo reply to the chat
+  - `AI: Select Model` (`aiAgent.selectModel`) opens a picker to select a Grok model variant
+
+Model selection
+- The header includes a dropdown to choose a Grok model variant (Grok 2, Grok 2 Mini, Grok 1.5, Grok 1).
+- The chosen model is stored in the `aiAgent.grok.model` setting and reflected in stubbed responses, e.g. `Echo (Grok 2 Mini): ...`.
 
 Notes
 - The chat is a simple webview view with no networking; responses are stubbed.

--- a/extensions/ai-agent/media/styles.css
+++ b/extensions/ai-agent/media/styles.css
@@ -165,6 +165,25 @@ body {
   filter: brightness(.96);
 }
 
+.ai-select {
+  border: 1px solid var(--ai-border);
+  background: var(--vscode-dropdown-background);
+  color: var(--vscode-dropdown-foreground);
+  padding: .25rem .5rem;
+  border-radius: .3rem;
+  cursor: pointer;
+}
+
+.ai-select:hover {
+  border-color: var(--ai-accent);
+}
+
+.ai-select:focus {
+  outline: none;
+  border-color: var(--ai-accent);
+  box-shadow: 0 0 0 1px var(--ai-accent) inset;
+}
+
 @media (max-width: 750px) {
   .ai-main { height: calc(100vh - 3.2rem); }
   .ai-tool { padding: .2rem .45rem; }

--- a/extensions/ai-agent/package.json
+++ b/extensions/ai-agent/package.json
@@ -14,7 +14,8 @@
     "onView:aiAgent.chat",
     "onCommand:aiAgent.open",
     "onCommand:aiAgent.sendMessage",
-    "onCommand:aiAgent.clear"
+    "onCommand:aiAgent.clear",
+    "onCommand:aiAgent.selectModel"
   ],
   "main": "./out/extension",
   "capabilities": {
@@ -54,10 +55,20 @@
         "command": "aiAgent.clear",
         "title": "AI: Clear Chat",
         "category": "AI"
+      },
+      {
+        "command": "aiAgent.selectModel",
+        "title": "AI: Select Model",
+        "category": "AI"
       }
     ],
     "menus": {
       "view/title": [
+        {
+          "command": "aiAgent.selectModel",
+          "when": "view == aiAgent.chat",
+          "group": "navigation@98"
+        },
         {
           "command": "aiAgent.clear",
           "when": "view == aiAgent.chat",
@@ -71,7 +82,24 @@
         "contents": "Welcome to AI Chat. Type a message below to start.",
         "when": "true"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "AI Agent",
+      "properties": {
+        "aiAgent.grok.model": {
+          "type": "string",
+          "default": "grok-2",
+          "enum": ["grok-2", "grok-2-mini", "grok-1.5", "grok-1"],
+          "enumDescriptions": [
+            "Strong general model (stubbed)",
+            "Fast and lightweight (stubbed)",
+            "Balanced capability (stubbed)",
+            "Legacy model (stubbed)"
+          ],
+          "description": "Grok model to use in the demo chat. Responses are stubbed."
+        }
+      }
+    }
   },
   "scripts": {
     "compile": "npx gulp compile-extension:ai-agent",

--- a/extensions/ai-agent/src/extension.ts
+++ b/extensions/ai-agent/src/extension.ts
@@ -9,6 +9,27 @@ interface ChatMessage {
 	ts: number;
 }
 
+type ModelId = 'grok-2' | 'grok-2-mini' | 'grok-1.5' | 'grok-1';
+
+const GROK_MODELS: ReadonlyArray<{ id: ModelId; label: string }> = [
+	{ id: 'grok-2', label: 'Grok 2' },
+	{ id: 'grok-2-mini', label: 'Grok 2 Mini' },
+	{ id: 'grok-1.5', label: 'Grok 1.5' },
+	{ id: 'grok-1', label: 'Grok 1' }
+];
+
+function modelLabel(id: string): string {
+	return GROK_MODELS.find(m => m.id === id as ModelId)?.label || id;
+}
+
+function getModel(): ModelId {
+	return vscode.workspace.getConfiguration('aiAgent').get<ModelId>('grok.model', 'grok-2');
+}
+
+async function setModel(id: ModelId) {
+	await vscode.workspace.getConfiguration('aiAgent').update('grok.model', id, true);
+}
+
 class AIChatViewProvider implements vscode.WebviewViewProvider {
 	public static readonly viewId = 'aiAgent.chat';
 	private _view?: vscode.WebviewView;
@@ -34,6 +55,8 @@ class AIChatViewProvider implements vscode.WebviewViewProvider {
 				case 'requestState': {
 					const state = load();
 					webview.postMessage({ type: 'state', messages: state });
+					const id = getModel();
+					webview.postMessage({ type: 'model', id, label: modelLabel(id) });
 					break;
 				}
 				case 'send': {
@@ -43,10 +66,17 @@ class AIChatViewProvider implements vscode.WebviewViewProvider {
 					const userMsg: ChatMessage = { id: genId(), role: 'user', text, ts: Date.now() };
 					save([...history, userMsg]);
 					webview.postMessage({ type: 'append', message: userMsg });
-					const response = await this._getStubbedResponse(text);
+					const model = getModel();
+					const response = await this._getStubbedResponse(text, model);
 					const aiMsg: ChatMessage = { id: genId(), role: 'assistant', text: response, ts: Date.now() };
 					save([...load(), aiMsg]);
 					webview.postMessage({ type: 'append', message: aiMsg });
+					break;
+				}
+				case 'setModel': {
+					const id = typeof msg.id === 'string' ? (msg.id as ModelId) : getModel();
+					await setModel(id);
+					webview.postMessage({ type: 'model', id, label: modelLabel(id) });
 					break;
 				}
 				case 'clear': {
@@ -56,17 +86,25 @@ class AIChatViewProvider implements vscode.WebviewViewProvider {
 				}
 			}
 		});
+
+		vscode.workspace.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('aiAgent.grok.model')) {
+				const id = getModel();
+				this._view?.webview.postMessage({ type: 'model', id, label: modelLabel(id) });
+			}
+		});
 	}
 
 	public post(text: string) {
 		this._view?.webview.postMessage({ type: 'append', message: { id: genId(), role: 'assistant', text, ts: Date.now() } satisfies ChatMessage });
 	}
 
-	private async _getStubbedResponse(text: string): Promise<string> {
+	private async _getStubbedResponse(text: string, model: ModelId): Promise<string> {
 		const trimmed = text.replace(/\s+/g, ' ').slice(0, 1000);
-		const echo = `Echo: ${trimmed}`;
-		await delay(100);
-		return echo;
+		const prefix = modelLabel(model);
+		const delayMs = model.endsWith('mini') ? 60 : 100;
+		await delay(delayMs);
+		return `Echo (${prefix}): ${trimmed}`;
 	}
 
 	private _getHtmlForWebview(webview: vscode.Webview): string {
@@ -74,119 +112,135 @@ class AIChatViewProvider implements vscode.WebviewViewProvider {
 		const stylesUri = webview.asWebviewUri(vscode.Uri.joinPath(this._context.extensionUri, 'media', 'styles.css'));
 		const iconUri = webview.asWebviewUri(vscode.Uri.joinPath(this._context.extensionUri, 'media', 'icon.png'));
 		return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} https: data:; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
-<link href="${stylesUri}" rel="stylesheet">
-<title>AI Chat</title>
-</head>
-<body>
-	<header class="ai-header">
-		<img class="ai-logo" src="${iconUri}" alt="" width="16" height="16"/>
-		<span class="ai-title">AI Chat</span>
-		<div class="ai-tools" role="toolbar" aria-label="Chat toolbar">
-			<button id="new" class="ai-tool" title="New chat" aria-label="New chat">New</button>
-			<button id="clear" class="ai-tool" title="Clear chat" aria-label="Clear chat">Clear</button>
-			<button id="copyLast" class="ai-tool" title="Copy last message" aria-label="Copy last message">Copy</button>
-		</div>
-	</header>
-	<main class="ai-main">
-		<div id="messages" class="ai-messages" aria-live="polite"></div>
-		<div class="ai-input">
-			<textarea id="input" rows="3" placeholder="Type a message…"></textarea>
-			<div class="ai-input-actions">
-				<label class="ai-hint">Enter to send • Shift+Enter for newline</label>
-				<button id="send" class="ai-send">Send</button>
+	<html lang="en">
+	<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} https: data:; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
+	<link href="${stylesUri}" rel="stylesheet">
+	<title>AI Chat</title>
+	</head>
+	<body>
+		<header class="ai-header">
+			<img class="ai-logo" src="${iconUri}" alt="" width="16" height="16"/>
+			<span class="ai-title">AI Chat</span>
+			<div class="ai-tools" role="toolbar" aria-label="Chat toolbar">
+				<label class="ai-hint" style="margin-right:.2rem">Model</label>
+				<select id="model" class="ai-select" title="Select model" aria-label="Select model">
+					<option value="grok-2">Grok 2</option>
+					<option value="grok-2-mini">Grok 2 Mini</option>
+					<option value="grok-1.5">Grok 1.5</option>
+					<option value="grok-1">Grok 1</option>
+				</select>
+				<button id="new" class="ai-tool" title="New chat" aria-label="New chat">New</button>
+				<button id="clear" class="ai-tool" title="Clear chat" aria-label="Clear chat">Clear</button>
+				<button id="copyLast" class="ai-tool" title="Copy last message" aria-label="Copy last message">Copy</button>
 			</div>
-		</div>
-	</main>
-	<script nonce="${nonce}">
-		const vscode = acquireVsCodeApi();
-		const messagesEl = document.getElementById('messages');
-		const inputEl = document.getElementById('input');
-		const sendEl = document.getElementById('send');
-		const clearEl = document.getElementById('clear');
-		const newEl = document.getElementById('new');
-		const copyLastEl = document.getElementById('copyLast');
+		</header>
+		<main class="ai-main">
+			<div id="messages" class="ai-messages" aria-live="polite"></div>
+			<div class="ai-input">
+				<textarea id="input" rows="3" placeholder="Type a message…"></textarea>
+				<div class="ai-input-actions">
+					<label class="ai-hint">Enter to send • Shift+Enter for newline</label>
+					<button id="send" class="ai-send">Send</button>
+				</div>
+			</div>
+		</main>
+		<script nonce="${nonce}">
+			const vscode = acquireVsCodeApi();
+			const messagesEl = document.getElementById('messages');
+			const inputEl = document.getElementById('input');
+			const sendEl = document.getElementById('send');
+			const clearEl = document.getElementById('clear');
+			const newEl = document.getElementById('new');
+			const copyLastEl = document.getElementById('copyLast');
+			const modelEl = document.getElementById('model');
 
-		function fmt(ts){ const d=new Date(ts); return d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}); }
-		function addMessage(msg){
-			const wrap=document.createElement('div');
-			wrap.className='ai-msg ' + (msg.role==='user'?'user':'assistant');
-			wrap.dataset.id = msg.id;
-			const bubble=document.createElement('div');
-			bubble.className='ai-bubble';
-			bubble.textContent=msg.text;
-			const meta=document.createElement('div');
-			meta.className='ai-meta';
-			meta.textContent = (msg.role==='user'?'You':'AI') + ' • ' + fmt(msg.ts);
-			wrap.appendChild(bubble);
-			wrap.appendChild(meta);
-			messagesEl.appendChild(wrap);
-			messagesEl.scrollTop = messagesEl.scrollHeight;
-		}
-		function clearAll(){
-			messagesEl.innerHTML='';
-			vscode.setState({ messages: [] });
-		}
-		function getState(){ return vscode.getState() || { messages: [] }; }
-		function setState(messages){ vscode.setState({ messages }); }
+			function fmt(ts){ const d=new Date(ts); return d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}); }
+			function addMessage(msg){
+				const wrap=document.createElement('div');
+				wrap.className='ai-msg ' + (msg.role==='user'?'user':'assistant');
+				wrap.dataset.id = msg.id;
+				const bubble=document.createElement('div');
+				bubble.className='ai-bubble';
+				bubble.textContent=msg.text;
+				const meta=document.createElement('div');
+				meta.className='ai-meta';
+				meta.textContent = (msg.role==='user'?'You':'AI') + ' • ' + fmt(msg.ts);
+				wrap.appendChild(bubble);
+				wrap.appendChild(meta);
+				messagesEl.appendChild(wrap);
+				messagesEl.scrollTop = messagesEl.scrollHeight;
+			}
+			function clearAll(){
+				messagesEl.innerHTML='';
+				vscode.setState({ messages: [] });
+			}
+			function getState(){ return vscode.getState() || { messages: [] }; }
+			function setState(messages){ vscode.setState({ messages }); }
 
-		sendEl.addEventListener('click', () => {
-			const text = inputEl.value.trim();
-			if (!text) return;
-			vscode.postMessage({ type:'send', text });
-			inputEl.value='';
-			inputEl.focus();
-		});
-		inputEl.addEventListener('keydown', (e) => {
-			if (e.key==='Enter' && !e.shiftKey) {
-				e.preventDefault();
-				sendEl.click();
-			}
-		});
-		clearEl.addEventListener('click', () => { vscode.postMessage({ type:'clear' }); });
-		newEl.addEventListener('click', () => { vscode.postMessage({ type:'clear' }); });
-		copyLastEl.addEventListener('click', async () => {
-			const els = messagesEl.querySelectorAll('.ai-bubble');
-			const last = els[els.length-1];
-			if (last && navigator.clipboard) {
-				try { await navigator.clipboard.writeText(last.textContent || ''); } catch {}
-			}
-		});
+			modelEl.addEventListener('change', () => {
+				const id = modelEl.value;
+				vscode.postMessage({ type:'setModel', id });
+			});
 
-		window.addEventListener('message', (event) => {
-			const msg = event.data;
-			if (!msg) return;
-			if (msg.type==='state') {
-				clearAll();
-				for (const m of msg.messages) addMessage(m);
-				setState(msg.messages);
-			}
-			if (msg.type==='append') {
-				addMessage(msg.message);
-				const cur = getState().messages || [];
-				setState([...cur, msg.message]);
-			}
-			if (msg.type==='cleared') {
-				clearAll();
-			}
-		});
+			sendEl.addEventListener('click', () => {
+				const text = inputEl.value.trim();
+				if (!text) return;
+				vscode.postMessage({ type:'send', text });
+				inputEl.value='';
+				inputEl.focus();
+			});
+			inputEl.addEventListener('keydown', (e) => {
+				if (e.key==='Enter' && !e.shiftKey) {
+					e.preventDefault();
+					sendEl.click();
+				}
+			});
+			clearEl.addEventListener('click', () => { vscode.postMessage({ type:'clear' }); });
+			newEl.addEventListener('click', () => { vscode.postMessage({ type:'clear' }); });
+			copyLastEl.addEventListener('click', async () => {
+				const els = messagesEl.querySelectorAll('.ai-bubble');
+				const last = els[els.length-1];
+				if (last && navigator.clipboard) {
+					try { await navigator.clipboard.writeText(last.textContent || ''); } catch {}
+				}
+			});
 
-		(function init(){
-			const s = getState();
-			if (!s.messages || s.messages.length===0) {
-				const hello = { id: '${'hi'}' + Math.random().toString(36).slice(2), role: 'assistant', text: 'Hi. This is a demo chat.', ts: Date.now() };
-				addMessage(hello);
-				setState([hello]);
-			}
-			vscode.postMessage({ type:'requestState' });
-		})();
-	</script>
-</body>
-</html>`;
+			window.addEventListener('message', (event) => {
+				const msg = event.data;
+				if (!msg) return;
+				if (msg.type==='state') {
+					clearAll();
+					for (const m of msg.messages) addMessage(m);
+					setState(msg.messages);
+				}
+				if (msg.type==='append') {
+					addMessage(msg.message);
+					const cur = getState().messages || [];
+					setState([...cur, msg.message]);
+				}
+				if (msg.type==='cleared') {
+					clearAll();
+				}
+				if (msg.type==='model') {
+					modelEl.value = msg.id;
+				}
+			});
+
+			(function init(){
+				const s = getState();
+				if (!s.messages || s.messages.length===0) {
+					const hello = { id: '${'hi'}' + Math.random().toString(36).slice(2), role: 'assistant', text: 'Hi. This is a demo chat.', ts: Date.now() };
+					addMessage(hello);
+					setState([hello]);
+				}
+				vscode.postMessage({ type:'requestState' });
+			})();
+		</script>
+	</body>
+	</html>`;
 	}
 }
 
@@ -199,14 +253,15 @@ export function activate(context: vscode.ExtensionContext) {
 		}),
 		vscode.commands.registerCommand('aiAgent.sendMessage', async () => {
 			const value = await vscode.window.showInputBox({ prompt: 'Send a message to AI Chat' });
-			if (value) { provider.post(`Echo: ${value}`); }
+			if (value) { provider.post(`Echo (${modelLabel(getModel())}): ${value}`); }
 		}),
-		vscode.commands.registerCommand('aiAgent.clear', async () => {
-			provider['post']('');
-			provider['post'] = provider['post'];
-			provider['post'];
-			provider;
-		})
+		vscode.commands.registerCommand('aiAgent.selectModel', async () => {
+			const picked = await vscode.window.showQuickPick(GROK_MODELS.map(m => m.label), { placeHolder: 'Select Grok model' });
+			if (!picked) { return; }
+			const entry = GROK_MODELS.find(m => m.label === picked)!;
+			await setModel(entry.id);
+		}),
+		vscode.commands.registerCommand('aiAgent.clear', async () => {})
 	);
 }
 


### PR DESCRIPTION
Summary\n- Add Grok model variants (Grok 2, Grok 2 Mini, Grok 1.5, Grok 1) selectable from header dropdown and command palette.\n- Stub provider echoes with model label for screenshot/demo parity; no networking added.\n- Persist selection in aiAgent.grok.model setting and listen for configuration changes.\n\nNature of changes\n- Enhancement to built-in demo extension (UI + settings).\n\nImpact\n- Enables believable Grok model switching in demo flows without external services.\n\nWhy\n- Matches screenshot scope and supports demos where different model variants need to be shown.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/49e6596b-4ece-4a5a-a8f5-eac89eee79b0/task/74ccec11-0315-46d1-b509-e810c43c2a95))